### PR TITLE
Add support for laravel 5.8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ composer.lock
 docs
 vendor
 coverage
+/.project
+/.settings/
+/.buildpath
+/.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -24,11 +24,11 @@
     "require": {
         "php": "^7.1",
         "ext-soap": "*",
-        "illuminate/contracts": "5.5.*|5.6.*|5.7.*",
-        "illuminate/support": "5.5.*|5.6.*|5.7.*"
+        "illuminate/contracts": "5.5.*|5.6.*|5.7.*|5.8.*",
+        "illuminate/support": "5.5.*|5.6.*|5.7.*|5.8.*"
     },
     "require-dev": {
-        "orchestra/testbench": "3.7.*",
+        "orchestra/testbench": "3.8.*",
         "phpunit/phpunit": "^7.5",
         "squizlabs/php_codesniffer": "^3.4"
     },

--- a/tests/Rules/VatNumberExistTest.php
+++ b/tests/Rules/VatNumberExistTest.php
@@ -11,7 +11,7 @@ class VatNumberExistTest extends TestCase
 
     protected $fake_vat;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Rules/VatNumberFormatTest.php
+++ b/tests/Rules/VatNumberFormatTest.php
@@ -11,7 +11,7 @@ class VatNumberFormatTest extends TestCase
 
     protected $fake_vat;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Rules/VatNumberTest.php
+++ b/tests/Rules/VatNumberTest.php
@@ -11,7 +11,7 @@ class VatNumberTest extends TestCase
 
     protected $fake_vat;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/VatValidatorTest.php
+++ b/tests/VatValidatorTest.php
@@ -11,7 +11,7 @@ class VatValidatorTest extends TestCase
 
     protected $fake_vat;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Vies/ViesTest.php
+++ b/tests/Vies/ViesTest.php
@@ -13,34 +13,28 @@ class ViesTest extends TestCase
 
     protected $client;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
         $this->client = new Client();
     }
 
-    /**
-     * @expectedException \Danielebarbaro\LaravelVatEuValidator\Vies\ViesException
-     */
     public function testClientEmptyDataException()
     {
+        $this->expectException(\Danielebarbaro\LaravelVatEuValidator\Vies\ViesException::class);
         $this->client->check('', '');
     }
 
-    /**
-     * @expectedException \Danielebarbaro\LaravelVatEuValidator\Vies\ViesException
-     */
     public function testClientEmptyVatNumberException()
     {
+        $this->expectException(\Danielebarbaro\LaravelVatEuValidator\Vies\ViesException::class);
         $this->client->check('IT', '');
     }
 
-    /**
-     * @expectedException \Danielebarbaro\LaravelVatEuValidator\Vies\ViesException
-     */
     public function testClientEmptyCountryException()
     {
+        $this->expectException(\Danielebarbaro\LaravelVatEuValidator\Vies\ViesException::class);
         $this->client->check('', '12345');
     }
 


### PR DESCRIPTION
Ciao Daniele,

Thanks for sharing your library. It's a nice piece of work.

Recently upgraded a project to laravel 5.8 and your library was yet not compatible with it.

Hence my PR which includes:
- Laravel 5.8 support
- PHPUnit 8 support (kept phpunit 7.5 but i changed the test annotation in order to make it compatible for 8.x)

I hope it'll help.

PR Travis Status

[![Build Status](https://img.shields.io/travis/danielebarbaro/laravel-vat-eu-validator/master.svg?style=flat-square)](https://travis-ci.org/danielebarbaro/laravel-vat-eu-validator/builds/517362000)