### PR TITLE
Update VIES endpoint URL to HTTPS

### DIFF
--- a/src/Vies/Client.php
+++ b/src/Vies/Client.php
@@ -11,7 +11,7 @@ class Client
     /**
      * @const string
      */
-    const URL = 'http://ec.europa.eu/taxation_customs/vies/checkVatService.wsdl';
+    const URL = 'https://ec.europa.eu/taxation_customs/vies/checkVatService.wsdl';
 
     /**
      * @var int


### PR DESCRIPTION
Hey Daniele,

Thanks for a very nice and well written ruleset. Very thankful! 👍 

I propose we update VIES WDSL URL to use HTTPS.

About 4 months ago VIES started returning 307 Temporary Redirect HTTP code when not using HTTPS. This adds extra 200 ms to the request because of the redirect.