### PR TITLE
Update info about translations in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,12 +94,12 @@ class Controller {
 ```
 
 ### Translations
-Just add and customize validation strings in `resources/lang/en/validation.php`
+Just add and customize validation strings in `lang/en/validation.php`
 ```
     ...
     'vat_number' => 'The :attribute must be a valid VAT number.',
     'vat_number_format' => 'The :attribute must be write in a valid number format {country_name}{vat_number}.',
-    'vat_number_exist' => 'VAT number :attribute  not exist.',
+    'vat_number_exist' => 'VAT number :attribute not exist.',
     ...
 ```
 


### PR DESCRIPTION
In newest Laravel version, the language files are not in `resources/...` anymore, but in `lang/...`. https://laravel.com/docs/10.x/localization#introduction