### PR TITLE
Add method for country support check

### DIFF
--- a/src/Facades/VatValidatorFacade.php
+++ b/src/Facades/VatValidatorFacade.php
@@ -5,6 +5,13 @@ namespace Danielebarbaro\LaravelVatEuValidator\Facades;
 use Danielebarbaro\LaravelVatEuValidator\VatValidator;
 use Illuminate\Support\Facades\Facade;
 
+/**
+ * @method bool validateFormat(string $vatNumber)
+ * @method bool validateExistence(string $vatNumber)
+ * @method bool validate(string $vatNumber)
+ * @method static int luhnCheck(string $vatNumber)
+ * @method static string countryIsSupported(string $country)
+ */
 class VatValidatorFacade extends Facade
 {
     /**

--- a/src/VatValidator.php
+++ b/src/VatValidator.php
@@ -62,6 +62,15 @@ class VatValidator
     }
 
     /**
+     * Return if a country is supported by this validator
+     * @param string $country
+     * @return bool
+     */
+    public static function countryIsSupported(string $country): bool {
+        return isset(self::$pattern_expression[$country]);
+    }
+
+    /**
      * Validate a VAT number format.
      * @param string $vatNumber
      * @return bool

--- a/tests/Rules/CountryIsSupportedTest.php
+++ b/tests/Rules/CountryIsSupportedTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Danielebarbaro\LaravelVatEuValidator\Tests\Rules;
+
+use Danielebarbaro\LaravelVatEuValidator\VatValidator;
+use Orchestra\Testbench\TestCase;
+
+class CountryIsSupportedTest extends TestCase
+{
+    public function testCountryIsSupported()
+    {
+        self::assertTrue(VatValidator::countryIsSupported('AT'));
+    }
+
+    public function testCountryIsNotSupported()
+    {
+        self::assertFalse(VatValidator::countryIsSupported('US'));
+    }
+}


### PR DESCRIPTION
Great package! Sometimes you accept tax ids or registrations from multiple countries. US for example you cannot validate against this (which makes sense), it would be great to have a function which allows to check if a country is supported. This PR addresses that. (Tests included).

It also adds method doc comment annotations to the facade for improved IDE support.