### PR TITLE
Fix validation extensions

### DIFF
--- a/src/Rules/VatNumber.php
+++ b/src/Rules/VatNumber.php
@@ -7,9 +7,14 @@ use Illuminate\Contracts\Validation\ValidationRule;
 
 class VatNumber implements ValidationRule
 {
+    public function isValid(mixed $value): bool
+    {
+        return VatValidator::validate($value);
+    }
+
     public function validate(string $attribute, mixed $value, \Closure $fail): void
     {
-        if (! VatValidator::validate($value)) {
+        if (! $this->isValid($value)) {
             $fail(__('The :attribute must be a valid VAT number.'));
         }
     }

--- a/src/Rules/VatNumberExist.php
+++ b/src/Rules/VatNumberExist.php
@@ -8,9 +8,14 @@ use Illuminate\Contracts\Validation\ValidationRule;
 
 class VatNumberExist implements ValidationRule
 {
+    public function isValid(mixed $value): bool
+    {
+        return VatValidator::validateExistence($value);
+    }
+
     public function validate(string $attribute, mixed $value, Closure $fail): void
     {
-        if (! VatValidator::validateExistence($value)) {
+        if (! $this->isValid($value)) {
             $fail(__('VAT number :attribute  not exist.'));
         }
     }

--- a/src/Rules/VatNumberFormat.php
+++ b/src/Rules/VatNumberFormat.php
@@ -7,9 +7,14 @@ use Illuminate\Contracts\Validation\ValidationRule;
 
 class VatNumberFormat implements ValidationRule
 {
+    public function isValid(mixed $value): bool
+    {
+        return VatValidator::validateFormat($value);
+    }
+
     public function validate(string $attribute, mixed $value, \Closure $fail): void
     {
-        if (! VatValidator::validateFormat($value)) {
+        if (! $this->isValid($value)) {
             $fail(__('The :attribute must be write in a valid number format {country_name}{vat_number}.'));
         }
     }

--- a/src/VatValidatorServiceProvider.php
+++ b/src/VatValidatorServiceProvider.php
@@ -19,25 +19,25 @@ class VatValidatorServiceProvider extends ServiceProvider
         /**
          * Register the "vat_number" validation rule.
          */
-        Validator::extend('vat_number', static function ($attribute, $value, $parameters, $validator): void {
+        Validator::extend('vat_number', static function ($attribute, $value, $parameters, $validator): bool {
             $rule = new VatNumber();
-            $rule->validate($attribute, $value, static fn (string $message = null): null => null);
+            return $rule->isValid($value);
         });
 
         /**
          * Register the "vat_number_exist" validation rule.
          */
-        Validator::extend('vat_number_exist', static function ($attribute, $value, $parameters, $validator): void {
+        Validator::extend('vat_number_exist', static function ($attribute, $value, $parameters, $validator): bool {
             $rule = new VatNumberExist();
-            $rule->validate($attribute, $value, static fn (string $message = null): null => null);
+            return $rule->isValid($value);
         });
 
         /**
          * Register the "vat_number_format" validation rule.
          */
-        Validator::extend('vat_number_format', static function ($attribute, $value, $parameters, $validator): void {
+        Validator::extend('vat_number_format', static function ($attribute, $value, $parameters, $validator): bool {
             $rule = new VatNumberFormat();
-            $rule->validate($attribute, $value, static fn (string $message = null): null => null);
+            return $rule->isValid($value);
         });
     }
 


### PR DESCRIPTION
```php
$request->validate([
	'vat_id' => [new \Danielebarbaro\LaravelVatEuValidator\Rules\VatNumberFormat()],
]);
```
Using rules as object works

---

```php
$request->validate([
	'vat_id' => 'vat_number_format',
]);
```
But using rules as string shortcut does not work

---

**Problem**
```php
// VatValidatorServiceProvider.php
Validator::extend('vat_number_format', static function ($attribute, $value, $parameters, $validator): void {
	$rule = new VatNumberFormat();
	$rule->validate($attribute, $value, static fn (string $message = null): null => null);
});
```
The function does the validation, but just completely ignores the result. It has to return the validation result as boolean.