### PR TITLE
Add Hungarian VAT number validation

### DIFF
--- a/src/VatValidator.php
+++ b/src/VatValidator.php
@@ -87,6 +87,10 @@ class VatValidator
             return $result % 10 == 0;
         }
 
+        if ($validate_rule && $country === 'HU') {
+            return $this->validateHuVat($number);
+        }
+
         return $validate_rule;
     }
 
@@ -134,6 +138,27 @@ class VatValidator
         }
 
         return $sum;
+    }
+
+    /**
+     * Validates a Hungarian VAT number.
+     *
+     * @param string $vat
+     * @return bool
+     */
+    private function validateHuVat(string $vat): bool
+    {
+        $checksum = (int) $vat[7];
+        $weights = [9, 7, 3, 1, 9, 7, 3];
+        $sum = 0;
+
+        foreach ($weights as $i => $weight) {
+            $sum += (int) $vat[$i] * $weight;
+        }
+
+        $calculatedChecksum = (10 - ($sum % 10)) % 10;
+
+        return $calculatedChecksum === $checksum;
     }
 
     /**

--- a/tests/VatValidatorTest.php
+++ b/tests/VatValidatorTest.php
@@ -34,6 +34,7 @@ class VatValidatorTest extends TestCase
         $vat_numbers = [
             '',
             'IT1234567890',
+            'HU23395381',
             'IT12345',
             'foobar123',
         ];
@@ -56,5 +57,15 @@ class VatValidatorTest extends TestCase
     {
         self::assertIsInt($this->validator->luhnCheck($this->fake_vat));
         self::assertNotEquals(0, $this->validator->luhnCheck($this->fake_vat));
+    }
+
+    public function testHuVatValidFormat(): void
+    {
+        self::assertTrue($this->validator->validateFormat('HU28395515'));
+    }
+
+    public function testHuVatInvalidFormat(): void
+    {
+        self::assertFalse($this->validator->validateFormat('HU28395514'));
     }
 }


### PR DESCRIPTION
- Implement checksum validation for Hungarian VAT numbers.
- Update `VatValidator.php` to include Hungarian VAT validation logic.
- Add tests for Hungarian VAT number validation in `VatValidatorTest.php`.