### PR TITLE
fix php8.4 notices

### DIFF
--- a/src/VatValidatorServiceProvider.php
+++ b/src/VatValidatorServiceProvider.php
@@ -21,7 +21,7 @@ class VatValidatorServiceProvider extends ServiceProvider
          */
         Validator::extend('vat_number', static function ($attribute, $value, $parameters, $validator): void {
             $rule = new VatNumber();
-            $rule->validate($attribute, $value, static fn (string $message = null): null => null);
+            $rule->validate($attribute, $value, static fn (?string $message = null): null => null);
         });
 
         /**
@@ -29,7 +29,7 @@ class VatValidatorServiceProvider extends ServiceProvider
          */
         Validator::extend('vat_number_exist', static function ($attribute, $value, $parameters, $validator): void {
             $rule = new VatNumberExist();
-            $rule->validate($attribute, $value, static fn (string $message = null): null => null);
+            $rule->validate($attribute, $value, static fn (?string $message = null): null => null);
         });
 
         /**
@@ -37,7 +37,7 @@ class VatValidatorServiceProvider extends ServiceProvider
          */
         Validator::extend('vat_number_format', static function ($attribute, $value, $parameters, $validator): void {
             $rule = new VatNumberFormat();
-            $rule->validate($attribute, $value, static fn (string $message = null): null => null);
+            $rule->validate($attribute, $value, static fn (?string $message = null): null => null);
         });
 
         $this->loadTranslationsFrom(realpath(__DIR__ . '/..').'/resources/lang', 'laravelVatEuValidator');


### PR DESCRIPTION
fixes these warnings:

```
PHP Deprecated:  {closure:{closure:Danielebarbaro\LaravelVatEuValidator\VatValidatorServiceProvider::boot():22}:24}(): Implicitly marking parameter $message as nullable is deprecated, the explicit nullable type must be used instead in ./src/VatValidatorServiceProvider.php on line 24

Deprecated: {closure:{closure:Danielebarbaro\LaravelVatEuValidator\VatValidatorServiceProvider::boot():22}:24}(): Implicitly marking parameter $message as nullable is deprecated, the explicit nullable type must be used instead in ./src/VatValidatorServiceProvider.php on line 24

PHP Deprecated:  {closure:{closure:Danielebarbaro\LaravelVatEuValidator\VatValidatorServiceProvider::boot():30}:32}(): Implicitly marking parameter $message as nullable is deprecated, the explicit nullable type must be used instead in ./src/VatValidatorServiceProvider.php on line 32

Deprecated: {closure:{closure:Danielebarbaro\LaravelVatEuValidator\VatValidatorServiceProvider::boot():30}:32}(): Implicitly marking parameter $message as nullable is deprecated, the explicit nullable type must be used instead in ./src/VatValidatorServiceProvider.php on line 32

PHP Deprecated:  {closure:{closure:Danielebarbaro\LaravelVatEuValidator\VatValidatorServiceProvider::boot():38}:40}(): Implicitly marking parameter $message as nullable is deprecated, the explicit nullable type must be used instead in ./src/VatValidatorServiceProvider.php on line 40

Deprecated: {closure:{closure:Danielebarbaro\LaravelVatEuValidator\VatValidatorServiceProvider::boot():38}:40}(): Implicitly marking parameter $message as nullable is deprecated, the explicit nullable type must be used instead in ./src/VatValidatorServiceProvider.php on line 40
```