### PR TITLE
feat(lookup): Add VatLookupResult DTO and lookup method for full VIES record retrieval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to `laravel-vat-eu-validator` will be documented in this file
 
+## Add VatLookupResult DTO and lookup method - 2026-04-30
+
+New `VatValidator::lookup()` method that returns a typed `VatLookupResult` DTO with the full VIES record (name, address, request date, and — when using the REST client — trader and match fields), instead of just a boolean. The format is validated locally first, so invalid VAT numbers throw a `ViesException` without hitting the VIES API.
+
+`ViesClientInterface` gains a `lookup()` method, implemented by both `ViesSoapClient` and `ViesRestClient`.
+
 ## Laravel 13 support - 2026-03-28
 
 Thanks to @sergix44 , we now have compatibility with Laravel 13! 🚀

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,57 @@
 
 All notable changes to `laravel-vat-eu-validator` will be documented in this file
 
-## Add VatLookupResult DTO and lookup method - 2026-04-30
+## VAT lookup DTO and typed VIES error handling - 2026-04-30
 
-New `VatValidator::lookup()` method that returns a typed `VatLookupResult` DTO with the full VIES record (name, address, request date, and — when using the REST client — trader and match fields), instead of just a boolean. The format is validated locally first, so invalid VAT numbers throw a `ViesException` without hitting the VIES API.
+### ✨ New Features
 
-`ViesClientInterface` gains a `lookup()` method, implemented by both `ViesSoapClient` and `ViesRestClient`.
+- **`VatValidator::lookup()`**: returns a typed `VatLookupResult` DTO with the
+  full VIES record (countryCode, vatNumber, valid, name, address, requestDate,
+  and the REST-only trader / match fields). The VAT format is validated
+  locally first — an invalid format throws a `ViesException` without calling
+  the API.
+- **`ViesClientInterface::lookup()`**: new method on both the SOAP and REST
+  clients returning the raw VIES payload as an array. Implementers of a
+  custom client must add this method.
+
+### 🐛 Bug Fixes
+
+- **REST client now detects application-level errors on HTTP 200**: the VIES
+  REST API can return `200 OK` with a body of
+  `{"actionSucceed": false, "errorWrappers": [{"error": "MS_MAX_CONCURRENT_REQ"}]}`.
+  Previously this slipped through as a successful response; it now throws
+  `ViesException` with the formatted message and error codes attached.
+  Affects both `/check-vat-number` and `/check-status`.
+
+### 🔍 Typed error codes on `ViesException`
+
+- All known VIES API error codes are now constants on `ViesException`:
+  `INVALID_INPUT`, `INVALID_REQUESTER_INFO`, `SERVICE_UNAVAILABLE`,
+  `MS_UNAVAILABLE`, `TIMEOUT`, `VAT_BLOCKED`, `IP_BLOCKED`,
+  `GLOBAL_MAX_CONCURRENT_REQ`, `GLOBAL_MAX_CONCURRENT_REQ_TIME`,
+  `MS_MAX_CONCURRENT_REQ`, `MS_MAX_CONCURRENT_REQ_TIME`.
+- New helpers: `getErrorCodes()`, `hasErrorCode(string)`, `isTransient()` —
+  letting callers retry on rate-limit / service-unavailable and fail fast on
+  permanent errors.
+
+```php
+try {
+    $result = VatValidator::lookup('IT00743110157');
+} catch (ViesException $e) {
+    if ($e->isTransient()) {
+        // Retry with backoff
+    }
+}
+```
+
+### 🧪 Testing
+
+- New unit tests in `tests/Vies/ViesRestClientTest.php` covering the
+  HTTP-200-with-`actionSucceed=false` path, multiple error wrappers, the
+  status endpoint, non-JSON bodies, and HTTP error responses without a VIES
+  error body.
+- New unit tests in `tests/VatLookupResultTest.php` covering the DTO mapping
+  for both REST and SOAP response shapes.
 
 ## Laravel 13 support - 2026-03-28
 

--- a/README.md
+++ b/README.md
@@ -123,6 +123,43 @@ VatValidator::validateFormat('IT12345678901');
 
 // Check VAT existence
 VatValidator::validateExistence('IT12345678901');
+
+// Look up the full VIES record
+VatValidator::lookup('IE6364992H');
+```
+
+#### Lookup
+
+`lookup()` returns a typed `VatLookupResult` DTO with the full VIES record, instead of just a boolean. The format is validated locally first; if it doesn't match the country pattern, a `ViesException` is thrown without calling the VIES API.
+
+```php
+use Danielebarbaro\LaravelVatEuValidator\Facades\VatValidatorFacade as VatValidator;
+use Danielebarbaro\LaravelVatEuValidator\VatLookupResult;
+
+$result = VatValidator::lookup('IE6364992H');
+
+$result->valid;       // bool
+$result->countryCode; // string  — e.g. "IE"
+$result->vatNumber;   // string  — e.g. "6364992H"
+$result->name;        // ?string — registered company name
+$result->address;     // ?string — registered address
+$result->requestDate; // ?DateTimeImmutable
+
+// Trader / match fields are populated only by the REST client
+// and will be null when the SOAP client is in use.
+$result->requestIdentifier;
+$result->traderName;
+$result->traderStreet;
+$result->traderPostalCode;
+$result->traderCity;
+$result->traderCompanyType;
+$result->traderNameMatch;
+$result->traderStreetMatch;
+$result->traderPostalCodeMatch;
+$result->traderCityMatch;
+$result->traderCompanyTypeMatch;
+
+$result->toArray(); // array<string, mixed> — useful for logging or JSON responses
 ```
 
 #### Validation

--- a/README.md
+++ b/README.md
@@ -123,44 +123,78 @@ VatValidator::validateFormat('IT12345678901');
 
 // Check VAT existence
 VatValidator::validateExistence('IT12345678901');
-
-// Look up the full VIES record
-VatValidator::lookup('IE6364992H');
 ```
 
-#### Lookup
+#### Looking up the full VIES record
 
-`lookup()` returns a typed `VatLookupResult` DTO with the full VIES record, instead of just a boolean. The format is validated locally first; if it doesn't match the country pattern, a `ViesException` is thrown without calling the VIES API.
+`lookup()` returns a typed `VatLookupResult` DTO with the trader name, address,
+request date, and (when the REST client is in use) the trader / match fields
+exposed by the official endpoint. The VAT format is validated locally first;
+an invalid format throws a `ViesException` without calling the API.
 
 ```php
 use Danielebarbaro\LaravelVatEuValidator\Facades\VatValidatorFacade as VatValidator;
-use Danielebarbaro\LaravelVatEuValidator\VatLookupResult;
 
-$result = VatValidator::lookup('IE6364992H');
+$result = VatValidator::lookup('IE6388047V');
 
-$result->valid;       // bool
-$result->countryCode; // string  — e.g. "IE"
-$result->vatNumber;   // string  — e.g. "6364992H"
-$result->name;        // ?string — registered company name
-$result->address;     // ?string — registered address
-$result->requestDate; // ?DateTimeImmutable
-
-// Trader / match fields are populated only by the REST client
-// and will be null when the SOAP client is in use.
-$result->requestIdentifier;
-$result->traderName;
-$result->traderStreet;
-$result->traderPostalCode;
-$result->traderCity;
-$result->traderCompanyType;
-$result->traderNameMatch;
-$result->traderStreetMatch;
-$result->traderPostalCodeMatch;
-$result->traderCityMatch;
-$result->traderCompanyTypeMatch;
-
-$result->toArray(); // array<string, mixed> — useful for logging or JSON responses
+$result->valid;        // bool
+$result->name;         // ?string
+$result->address;      // ?string
+$result->requestDate;  // ?DateTimeImmutable
+$result->traderName;   // ?string (REST only)
+$result->toArray();    // array<string, mixed>
 ```
+
+The trader-* and `requestIdentifier` fields are only populated by the REST
+client; under SOAP they are `null`.
+
+#### Error handling
+
+All VIES failures surface as `Danielebarbaro\LaravelVatEuValidator\Vies\ViesException`.
+For the REST client, this includes both transport-level failures (timeouts,
+HTTP 5xx) and application-level failures where the API returns HTTP 200 with
+`{"actionSucceed": false, "errorWrappers": [...]}`.
+
+The exception exposes the error codes from `errorWrappers` so callers can
+branch on rate limits and member-state outages vs. permanent errors. Known
+codes are available as constants on `ViesException`:
+
+| Constant | API code |
+|---|---|
+| `ERROR_INVALID_INPUT` | `INVALID_INPUT` |
+| `ERROR_INVALID_REQUESTER_INFO` | `INVALID_REQUESTER_INFO` |
+| `ERROR_SERVICE_UNAVAILABLE` | `SERVICE_UNAVAILABLE` |
+| `ERROR_MS_UNAVAILABLE` | `MS_UNAVAILABLE` |
+| `ERROR_TIMEOUT` | `TIMEOUT` |
+| `ERROR_VAT_BLOCKED` | `VAT_BLOCKED` |
+| `ERROR_IP_BLOCKED` | `IP_BLOCKED` |
+| `ERROR_GLOBAL_MAX_CONCURRENT_REQ` | `GLOBAL_MAX_CONCURRENT_REQ` |
+| `ERROR_GLOBAL_MAX_CONCURRENT_REQ_TIME` | `GLOBAL_MAX_CONCURRENT_REQ_TIME` |
+| `ERROR_MS_MAX_CONCURRENT_REQ` | `MS_MAX_CONCURRENT_REQ` |
+| `ERROR_MS_MAX_CONCURRENT_REQ_TIME` | `MS_MAX_CONCURRENT_REQ_TIME` |
+
+```php
+use Danielebarbaro\LaravelVatEuValidator\Facades\VatValidatorFacade as VatValidator;
+use Danielebarbaro\LaravelVatEuValidator\Vies\ViesException;
+
+try {
+    $result = VatValidator::lookup('IT00743110157');
+} catch (ViesException $e) {
+    if ($e->isTransient()) {
+        // Retry with backoff — VIES is rate-limiting or a Member State is down.
+    }
+
+    if ($e->hasErrorCode(ViesException::ERROR_INVALID_INPUT)) {
+        // Permanent: invalid VAT input.
+    }
+
+    $e->getErrorCodes(); // ['MS_MAX_CONCURRENT_REQ', ...]
+}
+```
+
+`isTransient()` returns `true` for `SERVICE_UNAVAILABLE`, `MS_UNAVAILABLE`,
+`TIMEOUT`, and any of the concurrency / rate-limit codes — i.e. errors where
+retrying after a backoff is appropriate.
 
 #### Validation
 

--- a/src/Facades/VatValidatorFacade.php
+++ b/src/Facades/VatValidatorFacade.php
@@ -2,6 +2,7 @@
 
 namespace Danielebarbaro\LaravelVatEuValidator\Facades;
 
+use Danielebarbaro\LaravelVatEuValidator\VatLookupResult;
 use Danielebarbaro\LaravelVatEuValidator\VatValidator;
 use Illuminate\Support\Facades\Facade;
 
@@ -9,6 +10,7 @@ use Illuminate\Support\Facades\Facade;
  * @method bool validateFormat(string $vatNumber)
  * @method bool validateExistence(string $vatNumber)
  * @method bool validate(string $vatNumber)
+ * @method VatLookupResult lookup(string $vatNumber)
  * @method static int luhnCheck(string $vatNumber)
  * @method static string countryIsSupported(string $country)
  */

--- a/src/VatLookupResult.php
+++ b/src/VatLookupResult.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Danielebarbaro\LaravelVatEuValidator;
+
+use DateTimeImmutable;
+use DateTimeInterface;
+use Throwable;
+
+/**
+ * Typed result of a VIES VAT lookup.
+ *
+ * Common fields (countryCode, vatNumber, valid, name, address, requestDate)
+ * are populated for both SOAP and REST clients. The trader-* and
+ * requestIdentifier fields are only returned by the REST client and
+ * will be null when the SOAP client is in use.
+ */
+final readonly class VatLookupResult
+{
+    public function __construct(
+        public string $countryCode,
+        public string $vatNumber,
+        public bool $valid,
+        public ?string $name,
+        public ?string $address,
+        public ?DateTimeImmutable $requestDate,
+        public ?string $requestIdentifier,
+        public ?string $traderName,
+        public ?string $traderStreet,
+        public ?string $traderPostalCode,
+        public ?string $traderCity,
+        public ?string $traderCompanyType,
+        public ?string $traderNameMatch,
+        public ?string $traderStreetMatch,
+        public ?string $traderPostalCodeMatch,
+        public ?string $traderCityMatch,
+        public ?string $traderCompanyTypeMatch,
+    ) {
+    }
+
+    /**
+     * Build the DTO from a raw VIES response payload (REST or SOAP).
+     *
+     * @param array<string, mixed> $data
+     */
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            countryCode: (string) ($data['countryCode'] ?? ''),
+            vatNumber: (string) ($data['vatNumber'] ?? ''),
+            valid: (bool) ($data['valid'] ?? false),
+            name: self::stringOrNull($data['name'] ?? null),
+            address: self::stringOrNull($data['address'] ?? null),
+            requestDate: self::parseDate($data['requestDate'] ?? null),
+            requestIdentifier: self::stringOrNull($data['requestIdentifier'] ?? null),
+            traderName: self::stringOrNull($data['traderName'] ?? null),
+            traderStreet: self::stringOrNull($data['traderStreet'] ?? null),
+            traderPostalCode: self::stringOrNull($data['traderPostalCode'] ?? null),
+            traderCity: self::stringOrNull($data['traderCity'] ?? null),
+            traderCompanyType: self::stringOrNull($data['traderCompanyType'] ?? null),
+            traderNameMatch: self::stringOrNull($data['traderNameMatch'] ?? null),
+            traderStreetMatch: self::stringOrNull($data['traderStreetMatch'] ?? null),
+            traderPostalCodeMatch: self::stringOrNull($data['traderPostalCodeMatch'] ?? null),
+            traderCityMatch: self::stringOrNull($data['traderCityMatch'] ?? null),
+            traderCompanyTypeMatch: self::stringOrNull($data['traderCompanyTypeMatch'] ?? null),
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'countryCode' => $this->countryCode,
+            'vatNumber' => $this->vatNumber,
+            'valid' => $this->valid,
+            'name' => $this->name,
+            'address' => $this->address,
+            'requestDate' => $this->requestDate?->format(DateTimeInterface::ATOM),
+            'requestIdentifier' => $this->requestIdentifier,
+            'traderName' => $this->traderName,
+            'traderStreet' => $this->traderStreet,
+            'traderPostalCode' => $this->traderPostalCode,
+            'traderCity' => $this->traderCity,
+            'traderCompanyType' => $this->traderCompanyType,
+            'traderNameMatch' => $this->traderNameMatch,
+            'traderStreetMatch' => $this->traderStreetMatch,
+            'traderPostalCodeMatch' => $this->traderPostalCodeMatch,
+            'traderCityMatch' => $this->traderCityMatch,
+            'traderCompanyTypeMatch' => $this->traderCompanyTypeMatch,
+        ];
+    }
+
+    private static function stringOrNull(mixed $value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        $string = (string) $value;
+
+        return $string === '' ? null : $string;
+    }
+
+    private static function parseDate(mixed $value): ?DateTimeImmutable
+    {
+        if ($value instanceof DateTimeImmutable) {
+            return $value;
+        }
+
+        if ($value instanceof DateTimeInterface) {
+            return DateTimeImmutable::createFromInterface($value);
+        }
+
+        if (! is_string($value) || $value === '') {
+            return null;
+        }
+
+        try {
+            return new DateTimeImmutable($value);
+        } catch (Throwable) {
+            return null;
+        }
+    }
+}

--- a/src/VatValidator.php
+++ b/src/VatValidator.php
@@ -172,6 +172,31 @@ class VatValidator
     }
 
     /**
+     * Look up the full VIES record for a VAT number.
+     *
+     * Accepts the full VAT number including the country prefix
+     * (e.g. "IE6364992H"). The format is validated locally first;
+     * if it doesn't match the country pattern, a ViesException is
+     * thrown without calling the VIES API.
+     *
+     * @param string $vatNumber Full VAT number incl. country (e.g. "IE6364992H").
+     * @return VatLookupResult
+     * @throws Vies\ViesException When the format is invalid or the VIES call fails.
+     */
+    public function lookup(string $vatNumber): VatLookupResult
+    {
+        $vatNumber = $this->vatCleaner($vatNumber);
+
+        if (! $this->validateFormat($vatNumber)) {
+            throw new Vies\ViesException("Invalid VAT number format: {$vatNumber}");
+        }
+
+        [$country, $number] = $this->splitVat($vatNumber);
+
+        return VatLookupResult::fromArray($this->client->lookup($country, $number));
+    }
+
+    /**
      * @param string $vatNumber
      * @return string
      */

--- a/src/Vies/ViesClientInterface.php
+++ b/src/Vies/ViesClientInterface.php
@@ -16,4 +16,19 @@ interface ViesClientInterface
      * @throws ViesException
      */
     public function check(string $countryCode, string $vatNumber): bool;
+
+    /**
+     * Look up the full VIES record for a VAT number.
+     *
+     * Returns the raw response data from the underlying VIES service
+     * (e.g. countryCode, vatNumber, valid, name, address, requestDate, ...).
+     *
+     * @param string $countryCode
+     * @param string $vatNumber
+     *
+     * @return array<string, mixed>
+     *
+     * @throws ViesException
+     */
+    public function lookup(string $countryCode, string $vatNumber): array;
 }

--- a/src/Vies/ViesException.php
+++ b/src/Vies/ViesException.php
@@ -6,5 +6,76 @@ use Exception;
 
 class ViesException extends Exception
 {
-    //
+    /**
+     * Known VIES API error codes returned in the CommonResponse.errorWrappers
+     * array when actionSucceed is false.
+     *
+     * @link https://ec.europa.eu/taxation_customs/vies/#/technical-information
+     */
+    public const ERROR_INVALID_INPUT = 'INVALID_INPUT';
+    public const ERROR_INVALID_REQUESTER_INFO = 'INVALID_REQUESTER_INFO';
+    public const ERROR_SERVICE_UNAVAILABLE = 'SERVICE_UNAVAILABLE';
+    public const ERROR_MS_UNAVAILABLE = 'MS_UNAVAILABLE';
+    public const ERROR_TIMEOUT = 'TIMEOUT';
+    public const ERROR_VAT_BLOCKED = 'VAT_BLOCKED';
+    public const ERROR_IP_BLOCKED = 'IP_BLOCKED';
+    public const ERROR_GLOBAL_MAX_CONCURRENT_REQ = 'GLOBAL_MAX_CONCURRENT_REQ';
+    public const ERROR_GLOBAL_MAX_CONCURRENT_REQ_TIME = 'GLOBAL_MAX_CONCURRENT_REQ_TIME';
+    public const ERROR_MS_MAX_CONCURRENT_REQ = 'MS_MAX_CONCURRENT_REQ';
+    public const ERROR_MS_MAX_CONCURRENT_REQ_TIME = 'MS_MAX_CONCURRENT_REQ_TIME';
+
+    /**
+     * Error codes considered transient — caller may retry after a backoff.
+     */
+    public const TRANSIENT_ERRORS = [
+        self::ERROR_SERVICE_UNAVAILABLE,
+        self::ERROR_MS_UNAVAILABLE,
+        self::ERROR_TIMEOUT,
+        self::ERROR_GLOBAL_MAX_CONCURRENT_REQ,
+        self::ERROR_GLOBAL_MAX_CONCURRENT_REQ_TIME,
+        self::ERROR_MS_MAX_CONCURRENT_REQ,
+        self::ERROR_MS_MAX_CONCURRENT_REQ_TIME,
+    ];
+
+    /**
+     * @var string[]
+     */
+    private array $errorCodes = [];
+
+    /**
+     * @param string[] $errorCodes
+     */
+    public function setErrorCodes(array $errorCodes): self
+    {
+        $this->errorCodes = array_values(array_filter(
+            $errorCodes,
+            static fn (string $code): bool => $code !== ''
+        ));
+
+        return $this;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getErrorCodes(): array
+    {
+        return $this->errorCodes;
+    }
+
+    public function hasErrorCode(string $code): bool
+    {
+        return in_array($code, $this->errorCodes, true);
+    }
+
+    public function isTransient(): bool
+    {
+        foreach ($this->errorCodes as $code) {
+            if (in_array($code, self::TRANSIENT_ERRORS, true)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
 }

--- a/src/Vies/ViesRestClient.php
+++ b/src/Vies/ViesRestClient.php
@@ -83,6 +83,27 @@ class ViesRestClient implements ViesClientInterface
     }
 
     /**
+     * Look up the full VIES record for a VAT number.
+     *
+     * Returns the raw CheckVatResponse payload from the official endpoint,
+     * which contains valid, name, address, trader-* and match fields.
+     *
+     * @param string $countryCode
+     * @param string $vatNumber
+     *
+     * @return array<string, mixed>
+     *
+     * @throws ViesException
+     */
+    public function lookup(string $countryCode, string $vatNumber): array
+    {
+        return $this->checkVatNumber([
+            'countryCode' => $countryCode,
+            'vatNumber' => $vatNumber,
+        ]);
+    }
+
+    /**
      * Test the check VAT service
      *
      * Official endpoint: POST /check-vat-test-service

--- a/src/Vies/ViesRestClient.php
+++ b/src/Vies/ViesRestClient.php
@@ -4,6 +4,7 @@ namespace Danielebarbaro\LaravelVatEuValidator\Vies;
 
 use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Http\Client\Response;
 use Illuminate\Support\Facades\Http;
 
 class ViesRestClient implements ViesClientInterface
@@ -131,48 +132,10 @@ class ViesRestClient implements ViesClientInterface
             $response = $this->getClient()
                 ->post("{$this->baseUrl}{$endpoint}", $requestData);
 
-            if ($response->failed()) {
-                $data = $response->json();
-
-                // Handle error response according to CommonResponse schema
-                if (isset($data['actionSucceed']) && $data['actionSucceed'] === false) {
-                    $errorMessage = $this->formatErrorMessage($data);
-
-                    throw new ViesException($errorMessage, $response->status());
-                }
-
-                throw new ViesException(
-                    'VIES REST API request failed: ' . $response->body(),
-                    $response->status()
-                );
-            }
-
-            return $response->json();
+            return $this->parseResponse($response);
         } catch (ConnectionException $e) {
             throw new ViesException($e->getMessage(), $e->getCode());
         }
-    }
-
-    /**
-     * Format error message from CommonResponse
-     *
-     * @param array $data
-     * @return string
-     */
-    private function formatErrorMessage(array $data): string
-    {
-        if (isset($data['errorWrappers']) && is_array($data['errorWrappers'])) {
-            $errors = array_map(function ($wrapper) {
-                $error = $wrapper['error'] ?? 'Unknown error';
-                $message = $wrapper['message'] ?? '';
-
-                return $message ? "{$error}: {$message}" : $error;
-            }, $data['errorWrappers']);
-
-            return 'VIES API errors: ' . implode(', ', $errors);
-        }
-
-        return 'VIES API request failed';
     }
 
     /**
@@ -189,24 +152,107 @@ class ViesRestClient implements ViesClientInterface
             $response = $this->getClient()
                 ->get("{$this->baseUrl}/check-status");
 
-            if ($response->failed()) {
-                $data = $response->json();
-
-                if (isset($data['actionSucceed']) && $data['actionSucceed'] === false) {
-                    $errorMessage = $this->formatErrorMessage($data);
-
-                    throw new ViesException($errorMessage, $response->status());
-                }
-
-                throw new ViesException(
-                    'VIES REST API request failed: ' . $response->body(),
-                    $response->status()
-                );
-            }
-
-            return $response->json();
+            return $this->parseResponse($response);
         } catch (ConnectionException $e) {
             throw new ViesException($e->getMessage(), $e->getCode());
         }
+    }
+
+    /**
+     * Parse a VIES response, throwing on transport-level failures and
+     * on application-level failures (HTTP 200 with actionSucceed=false).
+     *
+     * @return array<string, mixed>
+     * @throws ViesException
+     */
+    private function parseResponse(Response $response): array
+    {
+        $data = $response->json();
+        $isErrorBody = is_array($data) && ($data['actionSucceed'] ?? null) === false;
+
+        if ($response->failed() || $isErrorBody) {
+            throw $this->buildException($response, $data, $isErrorBody);
+        }
+
+        if (! is_array($data)) {
+            throw new ViesException(
+                'Invalid response format from VIES REST API',
+                $response->status()
+            );
+        }
+
+        return $data;
+    }
+
+    /**
+     * Build a ViesException for a failed response, attaching any error codes
+     * extracted from the CommonResponse.errorWrappers payload.
+     */
+    private function buildException(Response $response, mixed $data, bool $isErrorBody): ViesException
+    {
+        if ($isErrorBody && is_array($data)) {
+            $codes = $this->extractErrorCodes($data);
+
+            $exception = new ViesException(
+                $this->formatErrorMessage($data),
+                $response->status() ?: 0
+            );
+
+            return $exception->setErrorCodes($codes);
+        }
+
+        return new ViesException(
+            'VIES REST API request failed: ' . $response->body(),
+            $response->status()
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     * @return string[]
+     */
+    private function extractErrorCodes(array $data): array
+    {
+        if (! isset($data['errorWrappers']) || ! is_array($data['errorWrappers'])) {
+            return [];
+        }
+
+        $codes = [];
+
+        foreach ($data['errorWrappers'] as $wrapper) {
+            if (is_array($wrapper) && isset($wrapper['error']) && is_string($wrapper['error'])) {
+                $codes[] = $wrapper['error'];
+            }
+        }
+
+        return $codes;
+    }
+
+    /**
+     * Format error message from CommonResponse
+     *
+     * @param array $data
+     * @return string
+     */
+    private function formatErrorMessage(array $data): string
+    {
+        if (isset($data['errorWrappers']) && is_array($data['errorWrappers']) && $data['errorWrappers'] !== []) {
+            $errors = array_map(function ($wrapper) {
+                if (! is_array($wrapper)) {
+                    return 'Unknown error';
+                }
+
+                $error = isset($wrapper['error']) && is_string($wrapper['error']) && $wrapper['error'] !== ''
+                    ? $wrapper['error']
+                    : 'Unknown error';
+                $message = isset($wrapper['message']) && is_string($wrapper['message']) ? $wrapper['message'] : '';
+
+                return $message !== '' ? "{$error}: {$message}" : $error;
+            }, $data['errorWrappers']);
+
+            return 'VIES API errors: ' . implode(', ', $errors);
+        }
+
+        return 'VIES API request failed';
     }
 }

--- a/src/Vies/ViesSoapClient.php
+++ b/src/Vies/ViesSoapClient.php
@@ -54,6 +54,35 @@ class ViesSoapClient implements ViesClientInterface
     }
 
     /**
+     * Look up the full VIES record for a VAT number.
+     *
+     * Returns the SOAP checkVat response normalised to an array
+     * (countryCode, vatNumber, requestDate, valid, name, address).
+     *
+     * @param string $countryCode
+     * @param string $vatNumber
+     *
+     * @return array<string, mixed>
+     *
+     * @throws ViesException
+     */
+    public function lookup(string $countryCode, string $vatNumber): array
+    {
+        try {
+            $response = $this->getClient()->checkVat(
+                [
+                    'countryCode' => $countryCode,
+                    'vatNumber' => $vatNumber,
+                ]
+            );
+        } catch (SoapFault $soapFault) {
+            throw new ViesException($soapFault->getMessage(), $soapFault->getCode());
+        }
+
+        return (array) $response;
+    }
+
+    /**
      * Create SoapClient
      * @return SoapClient
      */

--- a/tests/Functional/VatValidatorRestFunctionalTest.php
+++ b/tests/Functional/VatValidatorRestFunctionalTest.php
@@ -251,6 +251,24 @@ class VatValidatorRestFunctionalTest extends TestCase
     }
 
     /**
+     * Test that VatValidator::lookup returns the typed VatLookupResult DTO
+     *
+     * Makes an actual REST API call via VatValidator::lookup and verifies
+     * the response is mapped to the DTO with the trader/identity fields
+     * exposed by the official endpoint.
+     */
+    public function testLookupReturnsFullViesRecord(): void
+    {
+        $result = $this->validator->lookup('IE6388047V');
+
+        $this->assertInstanceOf(\Danielebarbaro\LaravelVatEuValidator\VatLookupResult::class, $result);
+        $this->assertSame('IE', $result->countryCode);
+        $this->assertSame('6388047V', $result->vatNumber);
+        $this->assertIsBool($result->valid);
+        $this->assertNotNull($result->requestDate);
+    }
+
+    /**
      * Test the test service endpoint
      *
      * Verifies that the test endpoint is accessible.

--- a/tests/VatLookupResultTest.php
+++ b/tests/VatLookupResultTest.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Danielebarbaro\LaravelVatEuValidator\Tests;
+
+use Danielebarbaro\LaravelVatEuValidator\VatLookupResult;
+use DateTimeImmutable;
+use PHPUnit\Framework\TestCase;
+
+class VatLookupResultTest extends TestCase
+{
+    public function testFromArrayMapsRestResponseShape(): void
+    {
+        $payload = [
+            'countryCode' => 'IE',
+            'vatNumber' => '6364992H',
+            'requestDate' => '2026-04-30T09:32:20.253Z',
+            'valid' => true,
+            'requestIdentifier' => '',
+            'name' => 'ADOBE SYSTEMS SOFTWARE IRELAND LTD',
+            'address' => '4 - 6 RIVER WALK, CITYWEST BUSINESS CAMPUS, SAGGART, DUBLIN 24',
+            'traderName' => '---',
+            'traderStreet' => '---',
+            'traderPostalCode' => '---',
+            'traderCity' => '---',
+            'traderCompanyType' => '---',
+            'traderNameMatch' => 'NOT_PROCESSED',
+            'traderStreetMatch' => 'NOT_PROCESSED',
+            'traderPostalCodeMatch' => 'NOT_PROCESSED',
+            'traderCityMatch' => 'NOT_PROCESSED',
+            'traderCompanyTypeMatch' => 'NOT_PROCESSED',
+        ];
+
+        $result = VatLookupResult::fromArray($payload);
+
+        self::assertSame('IE', $result->countryCode);
+        self::assertSame('6364992H', $result->vatNumber);
+        self::assertTrue($result->valid);
+        self::assertSame('ADOBE SYSTEMS SOFTWARE IRELAND LTD', $result->name);
+        self::assertSame('4 - 6 RIVER WALK, CITYWEST BUSINESS CAMPUS, SAGGART, DUBLIN 24', $result->address);
+
+        self::assertInstanceOf(DateTimeImmutable::class, $result->requestDate);
+        self::assertSame('2026-04-30', $result->requestDate->format('Y-m-d'));
+
+        self::assertNull($result->requestIdentifier, 'empty strings should be null');
+        self::assertSame('---', $result->traderName);
+        self::assertSame('NOT_PROCESSED', $result->traderNameMatch);
+    }
+
+    public function testFromArrayMapsSoapResponseShapeWithMissingTraderFields(): void
+    {
+        $payload = [
+            'countryCode' => 'IE',
+            'vatNumber' => '6364992H',
+            'requestDate' => '2026-04-30+02:00',
+            'valid' => true,
+            'name' => 'ADOBE SYSTEMS SOFTWARE IRELAND LTD',
+            'address' => 'DUBLIN 24',
+        ];
+
+        $result = VatLookupResult::fromArray($payload);
+
+        self::assertSame('IE', $result->countryCode);
+        self::assertTrue($result->valid);
+        self::assertSame('ADOBE SYSTEMS SOFTWARE IRELAND LTD', $result->name);
+        self::assertInstanceOf(DateTimeImmutable::class, $result->requestDate);
+
+        self::assertNull($result->requestIdentifier);
+        self::assertNull($result->traderName);
+        self::assertNull($result->traderStreet);
+        self::assertNull($result->traderNameMatch);
+    }
+
+    public function testFromArrayHandlesUnparseableDate(): void
+    {
+        $result = VatLookupResult::fromArray([
+            'countryCode' => 'IE',
+            'vatNumber' => '6364992H',
+            'valid' => false,
+            'requestDate' => 'not-a-date',
+        ]);
+
+        self::assertNull($result->requestDate);
+        self::assertFalse($result->valid);
+    }
+
+    public function testToArrayRoundTripsTheDto(): void
+    {
+        $result = VatLookupResult::fromArray([
+            'countryCode' => 'IE',
+            'vatNumber' => '6364992H',
+            'valid' => true,
+            'name' => 'ACME',
+            'address' => '1 Example St',
+            'requestDate' => '2026-04-30T09:32:20+00:00',
+        ]);
+
+        $array = $result->toArray();
+
+        self::assertSame('IE', $array['countryCode']);
+        self::assertSame('6364992H', $array['vatNumber']);
+        self::assertTrue($array['valid']);
+        self::assertSame('ACME', $array['name']);
+        self::assertSame('2026-04-30T09:32:20+00:00', $array['requestDate']);
+        self::assertNull($array['traderName']);
+    }
+}

--- a/tests/VatValidatorTest.php
+++ b/tests/VatValidatorTest.php
@@ -2,8 +2,11 @@
 
 namespace Danielebarbaro\LaravelVatEuValidator\Tests;
 
+use Danielebarbaro\LaravelVatEuValidator\VatLookupResult;
 use Danielebarbaro\LaravelVatEuValidator\VatValidator;
 use Danielebarbaro\LaravelVatEuValidator\VatValidatorServiceProvider;
+use Danielebarbaro\LaravelVatEuValidator\Vies\ViesClientInterface;
+use Danielebarbaro\LaravelVatEuValidator\Vies\ViesException;
 use Orchestra\Testbench\TestCase;
 
 class VatValidatorTest extends TestCase
@@ -75,5 +78,69 @@ class VatValidatorTest extends TestCase
     public function testHuVatInvalidFormat(): void
     {
         self::assertFalse($this->validator->validateFormat('HU28395514'));
+    }
+
+    public function testLookupAcceptsFullVatNumberAndReturnsDto(): void
+    {
+        $stubClient = $this->makeRecordingClient();
+
+        $validator = new VatValidator($stubClient);
+
+        $result = $validator->lookup(' ie6364992h ');
+
+        self::assertSame(1, $stubClient->lookupCalls);
+        self::assertSame('IE', $stubClient->receivedCountry);
+        self::assertSame('6364992H', $stubClient->receivedNumber);
+
+        self::assertInstanceOf(VatLookupResult::class, $result);
+        self::assertSame('IE', $result->countryCode);
+        self::assertSame('6364992H', $result->vatNumber);
+        self::assertTrue($result->valid);
+        self::assertSame('ACME LTD', $result->name);
+        self::assertSame('1 Example Street', $result->address);
+    }
+
+    public function testLookupThrowsWithoutCallingApiWhenFormatIsInvalid(): void
+    {
+        $stubClient = $this->makeRecordingClient();
+
+        $validator = new VatValidator($stubClient);
+
+        try {
+            $validator->lookup('IT12345');
+            self::fail('Expected ViesException was not thrown');
+        } catch (ViesException $e) {
+            self::assertStringContainsString('Invalid VAT number format', $e->getMessage());
+            self::assertSame(0, $stubClient->lookupCalls, 'Client must not be called for invalid formats');
+        }
+    }
+
+    private function makeRecordingClient(): ViesClientInterface
+    {
+        return new class () implements ViesClientInterface {
+            public int $lookupCalls = 0;
+            public ?string $receivedCountry = null;
+            public ?string $receivedNumber = null;
+
+            public function check(string $countryCode, string $vatNumber): bool
+            {
+                return true;
+            }
+
+            public function lookup(string $countryCode, string $vatNumber): array
+            {
+                $this->lookupCalls++;
+                $this->receivedCountry = $countryCode;
+                $this->receivedNumber = $vatNumber;
+
+                return [
+                    'countryCode' => $countryCode,
+                    'vatNumber' => $vatNumber,
+                    'valid' => true,
+                    'name' => 'ACME LTD',
+                    'address' => '1 Example Street',
+                ];
+            }
+        };
     }
 }

--- a/tests/Vies/ViesRestClientTest.php
+++ b/tests/Vies/ViesRestClientTest.php
@@ -1,0 +1,166 @@
+<?php
+
+namespace Danielebarbaro\LaravelVatEuValidator\Tests\Vies;
+
+use Danielebarbaro\LaravelVatEuValidator\VatValidatorServiceProvider;
+use Danielebarbaro\LaravelVatEuValidator\Vies\ViesException;
+use Danielebarbaro\LaravelVatEuValidator\Vies\ViesRestClient;
+use Illuminate\Support\Facades\Http;
+use Orchestra\Testbench\TestCase;
+
+class ViesRestClientTest extends TestCase
+{
+    private ViesRestClient $client;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->client = new ViesRestClient();
+    }
+
+    protected function getPackageProviders($app): array
+    {
+        return [
+            VatValidatorServiceProvider::class,
+        ];
+    }
+
+    public function testCheckVatNumberThrowsWhenResponseHas200ButActionSucceedFalse(): void
+    {
+        Http::fake([
+            '*/check-vat-number' => Http::response([
+                'actionSucceed' => false,
+                'errorWrappers' => [
+                    ['error' => 'MS_MAX_CONCURRENT_REQ'],
+                ],
+            ], 200),
+        ]);
+
+        try {
+            $this->client->checkVatNumber([
+                'countryCode' => 'IT',
+                'vatNumber' => '00743110157',
+            ]);
+            $this->fail('Expected ViesException was not thrown');
+        } catch (ViesException $e) {
+            self::assertStringContainsString('MS_MAX_CONCURRENT_REQ', $e->getMessage());
+            self::assertSame(['MS_MAX_CONCURRENT_REQ'], $e->getErrorCodes());
+            self::assertTrue($e->hasErrorCode(ViesException::ERROR_MS_MAX_CONCURRENT_REQ));
+            self::assertTrue($e->isTransient());
+        }
+    }
+
+    public function testCheckThrowsForActionSucceedFalseWithMultipleErrors(): void
+    {
+        Http::fake([
+            '*/check-vat-number' => Http::response([
+                'actionSucceed' => false,
+                'errorWrappers' => [
+                    ['error' => 'MS_UNAVAILABLE', 'message' => 'Member State unavailable'],
+                    ['error' => 'TIMEOUT'],
+                ],
+            ], 200),
+        ]);
+
+        try {
+            $this->client->check('DE', '123456789');
+            $this->fail('Expected ViesException was not thrown');
+        } catch (ViesException $e) {
+            self::assertSame(['MS_UNAVAILABLE', 'TIMEOUT'], $e->getErrorCodes());
+            self::assertStringContainsString('MS_UNAVAILABLE: Member State unavailable', $e->getMessage());
+            self::assertStringContainsString('TIMEOUT', $e->getMessage());
+            self::assertTrue($e->isTransient());
+        }
+    }
+
+    public function testCheckThrowsForNonTransientError(): void
+    {
+        Http::fake([
+            '*/check-vat-number' => Http::response([
+                'actionSucceed' => false,
+                'errorWrappers' => [
+                    ['error' => 'INVALID_INPUT'],
+                ],
+            ], 400),
+        ]);
+
+        try {
+            $this->client->check('XX', '0');
+            $this->fail('Expected ViesException was not thrown');
+        } catch (ViesException $e) {
+            self::assertTrue($e->hasErrorCode(ViesException::ERROR_INVALID_INPUT));
+            self::assertFalse($e->isTransient());
+            self::assertSame(400, $e->getCode());
+        }
+    }
+
+    public function testCheckReturnsValidWhenResponseSucceeds(): void
+    {
+        Http::fake([
+            '*/check-vat-number' => Http::response([
+                'countryCode' => 'IE',
+                'vatNumber' => '6388047V',
+                'valid' => true,
+                'name' => 'GOOGLE IRELAND LIMITED',
+                'address' => '3RD FLOOR, GORDON HOUSE, BARROW STREET',
+            ], 200),
+        ]);
+
+        self::assertTrue($this->client->check('IE', '6388047V'));
+    }
+
+    public function testGetViesStatusThrowsOnActionSucceedFalse(): void
+    {
+        Http::fake([
+            '*/check-status' => Http::response([
+                'actionSucceed' => false,
+                'errorWrappers' => [
+                    ['error' => 'SERVICE_UNAVAILABLE'],
+                ],
+            ], 200),
+        ]);
+
+        try {
+            $this->client->getViesStatus();
+            $this->fail('Expected ViesException was not thrown');
+        } catch (ViesException $e) {
+            self::assertTrue($e->hasErrorCode(ViesException::ERROR_SERVICE_UNAVAILABLE));
+            self::assertTrue($e->isTransient());
+        }
+    }
+
+    public function testCheckThrowsOnNonJsonOrEmptyBody(): void
+    {
+        Http::fake([
+            '*/check-vat-number' => Http::response('not json', 200),
+        ]);
+
+        $this->expectException(ViesException::class);
+        $this->expectExceptionMessage('Invalid response format from VIES REST API');
+
+        $this->client->checkVatNumber([
+            'countryCode' => 'IT',
+            'vatNumber' => '00743110157',
+        ]);
+    }
+
+    public function testCheckThrowsOnHttpErrorWithoutErrorBody(): void
+    {
+        Http::fake([
+            '*/check-vat-number' => Http::response('Internal Server Error', 500),
+        ]);
+
+        try {
+            $this->client->checkVatNumber([
+                'countryCode' => 'IT',
+                'vatNumber' => '00743110157',
+            ]);
+            $this->fail('Expected ViesException was not thrown');
+        } catch (ViesException $e) {
+            self::assertSame(500, $e->getCode());
+            self::assertStringContainsString('Internal Server Error', $e->getMessage());
+            self::assertSame([], $e->getErrorCodes());
+        }
+    }
+}


### PR DESCRIPTION
Introduce typed `VatLookupResult` DTO to represent complete VIES responses, including trader-specific fields returned by the REST API. Implement `lookup()` method in `VatValidator`, `ViesClientInterface`, `ViesSoapClient`, and `ViesRestClient` to fetch and return full VIES records. Add comprehensive unit and functional tests for the new lookup functionality.