### PR TITLE
Drop Laravel 10 and 11 from the CI matrix

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -18,29 +18,20 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         php: [8.5, 8.4, 8.3, 8.2]
-        laravel: ['10.*', '11.*', '12.*', '13.*']
+        # Laravel 10 and 11 are EOL and every released version is flagged by a
+        # security advisory, so Composer refuses to install them. They are no
+        # longer covered by CI even though composer.json still allows them.
+        laravel: ['12.*', '13.*']
         stability: [prefer-lowest, prefer-stable]
         include:
-          - laravel: 10.*
-            testbench: ^8.21
-          - laravel: 11.*
-            testbench: ^9.5
           - laravel: 12.*
-            testbench: ^10.0
+            testbench: ^10.11
           - laravel: 13.*
             testbench: ^11.0
         exclude:
           # PHP 8.2 does not support Laravel 13
           - php: 8.2
             laravel: 13.*
-          # PHP 8.4 does not support Laravel 10
-          - php: 8.4
-            laravel: 10.*
-          # PHP 8.5 does not support Laravel 10, 11
-          - php: 8.5
-            laravel: 10.*
-          - php: 8.5
-            laravel: 11.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ laravel-vat-eu-validator is a package inspired from [vat.php](https://github.com
 
 #### For Laravel 10, 11, 12, 13 use tag 3.x
 
+> **Note on Laravel 10 and 11.** Both branches are end of life and every released version is flagged by a Composer security advisory, so Composer 2.9 and later refuse to install them by default. The package constraints still allow them, but CI only covers Laravel 12 and 13. If you are still on Laravel 10 or 11, plan an upgrade.
+
 #### For Laravel 10, 11, 12 use tag 2.x (legacy SOAP-only)
 
 #### For Laravel 8, 9 use tag 1.20

--- a/composer.json
+++ b/composer.json
@@ -31,12 +31,12 @@
     "require-dev": {
         "driftingly/rector-laravel": "^2.0",
         "friendsofphp/php-cs-fixer": "^3.59",
-        "orchestra/testbench": "^v8.37.0|^v9.16.0|^v10.9.0|^v11.0.0",
+        "orchestra/testbench": "^v10.11.0|^v11.0.0",
         "phpstan/extension-installer": "^1.4",
         "phpstan/phpstan": "^2.1",
         "phpstan/phpstan-deprecation-rules": "^2.0",
         "phpstan/phpstan-phpunit": "^2.0",
-        "phpunit/phpunit": "^10.5|^11.0|^12.0|^13.0",
+        "phpunit/phpunit": "^11.5.50|^12.0|^13.0",
         "rector/rector": "^2.0"
     },
     "autoload": {


### PR DESCRIPTION
CI started failing on every job without any code change.

Composer 2.9 blocks packages affected by security advisories by default. Advisory `PKSA-mdq4-51ck-6kdq` covers `>=10.0.0,<11.0.0` and `>=11.0.0,<12.0.0`, so no Laravel 10 or 11 release can be installed anymore. Both branches are EOL, so a patched release will never exist.

Changes:

* CI matrix limited to Laravel 12 and 13, testbench for Laravel 12 raised to `^10.11`
* `orchestra/testbench` and `phpunit/phpunit` dev constraints raised to versions that resolve cleanly
* README note explaining why Laravel 10 and 11 can no longer be installed

The `require` constraints are untouched, so nothing changes for existing users.