### PR TITLE
Fix some regex, resolve regex alternation leakage and add and rectify FR/IT/HU validation logic

### DIFF
--- a/resources/lang/fr/validation.php
+++ b/resources/lang/fr/validation.php
@@ -1,0 +1,6 @@
+<?php
+return [
+    'vat_number' => 'Le champ :attribute doit être un numéro de TVA valide.',
+    'vat_number_format' => 'Le champ :attribute doit être écrit dans un format valide {nom_pays}{numéro_tva}.',
+    'vat_number_exist' => 'Le numéro de TVA :attribute n\'existe pas.',
+];

--- a/src/VatValidator.php
+++ b/src/VatValidator.php
@@ -9,27 +9,25 @@ class VatValidator
     /**
      * Regular expression patterns per country code
      *
-     * @var array
+     * @var array<string, string>
      * @link http://ec.europa.eu/taxation_customs/vies/faq.html?locale=en#item_11
      */
     protected static array $pattern_expression = [
         'AT' => 'U[A-Z\d]{8}',
-        'BE' => '(0\d{9}|\d{10})',
+        'BE' => '[01]\d{9}',
         'BG' => '\d{9,10}',
-        'CH' => '^\d{6}$|^[E]\d{9}\s?(TVA|MWST|IVA)$',
         'CY' => '\d{8}[A-Z]',
         'CZ' => '\d{8,10}',
         'DE' => '\d{9}',
-        'DK' => '(\d{2} ?){3}\d{2}',
+        'DK' => '\d{8}',
         'EE' => '\d{9}',
         'EL' => '\d{9}',
-        'ES' => '[A-Z]\d{7}[A-Z]|\d{8}[A-Z]|[A-Z]\d{8}',
+        'ES' => '(?:[A-Z]\d{7}[A-Z]|\d{8}[A-Z]|[A-Z]\d{8})',
         'FI' => '\d{8}',
-        'FR' => '([A-Z]{2}|\d{2})\d{9}',
-        'GB' => '\d{9}|\d{12}|(GD|HA)\d{3}',
+        'FR' => '[0-9A-HJ-NP-Z]{2}[0-9]{9}',
         'HR' => '\d{11}',
         'HU' => '\d{8}',
-        'IE' => '[A-Z\d]{8}|[A-Z\d]{9}',
+        'IE' => '(?:\d{7}[A-W][A-W]?|\d[A-Z\d]\d{5}[A-W])',
         'IT' => '\d{11}',
         'LT' => '(\d{9}|\d{12})',
         'LU' => '\d{8}',
@@ -42,11 +40,11 @@ class VatValidator
         'SE' => '\d{12}',
         'SI' => '\d{8}',
         'SK' => '\d{10}',
+        'XI' => '(?:\d{9}|\d{12}|(?:GD|HA)\d{3})',
     ];
 
     /**
      * VatValidator constructor.
-     * @param ViesClientInterface $client
      */
     public function __construct(private readonly ViesClientInterface $client)
     {
@@ -54,8 +52,6 @@ class VatValidator
 
     /**
      * Return if a country is supported by this validator
-     * @param string $country
-     * @return bool
      */
     public static function countryIsSupported(string $country): bool
     {
@@ -64,14 +60,11 @@ class VatValidator
 
     /**
      * Validate a VAT number format.
-     * @param string $vatNumber
-     * @return bool
      */
-    public function validateFormat(string $vatNumber): bool
+    public function validateFormat(string $vatNumber, ?string $defaultCountry = null): bool
     {
         $vatNumber = $this->vatCleaner($vatNumber);
-        [$country, $number] = $this->splitVat($vatNumber);
-
+        [$country, $number] = $this->splitVat($vatNumber, $defaultCountry);
 
         if (! isset(self::$pattern_expression[$country])) {
             return false;
@@ -79,10 +72,12 @@ class VatValidator
 
         $validate_rule = preg_match('/^' . self::$pattern_expression[$country] . '$/', (string) $number) > 0;
 
+        if ($validate_rule && $country === 'FR') {
+            return $this->validateFrVat($number);
+        }
+        
         if ($validate_rule && $country === 'IT') {
-            $result = self::luhnCheck($number);
-
-            return $result % 10 == 0;
+            return $this->validateItVat($number);
         }
 
         if ($validate_rule && $country === 'HU') {
@@ -93,58 +88,27 @@ class VatValidator
     }
 
     /**
-     * Check existence VAT number
-     * @param string $vatNumber
-     * @return bool
+     * Check existence VAT number in VIES database
+     *
      * @throws Vies\ViesException
      */
-    public function validateExistence(string $vatNumber): bool
+    public function validateExistence(string $vatNumber, ?string $defaultCountry = null): bool
     {
         $vatNumber = $this->vatCleaner($vatNumber);
-        $result = $this->validateFormat($vatNumber);
-
-        if ($result) {
-            [$country, $number] = $this->splitVat($vatNumber);
-            $result = $this->client->check($country, $number);
+        
+        if (! $this->validateFormat($vatNumber, $defaultCountry)) {
+            return false;
         }
 
-        return $result;
-    }
+        [$country, $number] = $this->splitVat($vatNumber, $defaultCountry);
 
-    /**
-     * A php implementation of Luhn Algo
-     *
-     * @link https://en.wikipedia.org/wiki/Luhn_algorithm
-     * @param  string  $vat
-     * @return int
-     */
-    public static function luhnCheck(string $vat): int
-    {
-        $sum = 0;
-        $vat_array = str_split($vat);
-        $counter = count($vat_array);
-        for ($index = 0; $index < $counter; ++$index) {
-            $value = intval($vat_array[$index]);
-            if ($index % 2 !== 0) {
-                $value *= 2;
-                if ($value > 9) {
-                    $value = 1 + ($value % 10);
-                }
-            }
-
-            $sum += $value;
-        }
-
-        return $sum;
+        return $this->client->check($country, $number);
     }
 
     /**
      * Validates a Hungarian VAT number.
-     *
-     * @param string $vatNumber
-     * @return bool
      */
-    private function validateHuVat(string $vatNumber): bool
+    protected function validateHuVat(string $vatNumber): bool
     {
         $checksum = (int) $vatNumber[7];
         $weights = [9, 7, 3, 1, 9, 7, 3];
@@ -160,36 +124,150 @@ class VatValidator
     }
 
     /**
-     * Validates a VAT number .
-     *
-     * @param string $vatNumber Either the full VAT number (incl. country).
-     * @return bool
-     * @throws Vies\ViesException
+     * Validates an Italian VAT number.
      */
-    public function validate(string $vatNumber): bool
+    protected function validateItVat(string $vatNumber): bool
     {
-        return $this->validateFormat($vatNumber) && $this->validateExistence($vatNumber);
+        if (!preg_match('/^[0-9]{11}$/', $vatNumber)) {
+            return false;
+        }
+
+        if ($vatNumber === '00000000000') {
+            return false;
+        }
+
+        $officeCode = (int) substr($vatNumber, 7, 3);
+        $validOffice = ($officeCode >= 1 && $officeCode <= 100) 
+            || in_array($officeCode, [120, 121, 888, 999], true);
+
+        if (!$validOffice) {
+            return false;
+        }
+
+        $sum = 0;
+        for ($i = 0; $i < 10; $i++) {
+            $digit = (int) $vatNumber[$i];
+            
+            if ($i % 2 === 0) {
+                $sum += $digit;
+            } else {
+                $double = $digit * 2;
+                $sum += ($double > 9) ? ($double - 9) : $double;
+            }
+        }
+
+        $check = (10 - ($sum % 10)) % 10;
+
+        return $check === (int) $vatNumber[10];
     }
 
     /**
-     * @param string $vatNumber
-     * @return string
+     * Validates a French VAT number.
+     */
+    protected function validateFrVat(string $vatNumber): bool
+    {
+        // 1. Strict format check: 2 alphanumeric characters followed by 9 digits
+        if (!preg_match('/^[0-9A-HJ-NP-Z]{2}[0-9]{9}$/', $vatNumber)) {
+            return false;
+        }
+
+        $key = substr($vatNumber, 0, 2);
+        $siren = substr($vatNumber, 2);
+
+        // 2. Mathematical check on 2-digit numeric keys (Modulo 97)
+        if (ctype_digit($key)) {
+            $sirenInt = (int) $siren;
+            $computed = (12 + 3 * ($sirenInt % 97)) % 97;
+
+            if (sprintf('%02d', $computed) !== $key) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Validates a VAT number (format + VIES existence).
+     *
+     * @throws Vies\ViesException
+     */
+    public function validate(string $vatNumber, ?string $defaultCountry = null): bool
+    {
+        return $this->validateExistence($vatNumber, $defaultCountry);
+    }
+
+    /**
+     * Cleans a VAT number by removing spaces, dots, dashes and converting to uppercase.
      */
     private function vatCleaner(string $vatNumber): string
     {
-        $vatNumber_no_spaces = trim($vatNumber);
+        $clean = preg_replace('/[\s\.\-]+/', '', $vatNumber);
 
-        return strtoupper($vatNumber_no_spaces);
+        return strtoupper((string) $clean);
     }
 
     /**
-     * @param string $vatNumber
-     * @return array
+     * Splits a VAT number into its country code and the rest of the number.
+     *
+     * @return array{0: string, 1: string}
      */
-    private function splitVat(string $vatNumber): array
+    private function splitVat(string $vatNumber, ?string $defaultCountry = null): array
     {
+        $prefix = substr($vatNumber, 0, 2);
+
+        if ($prefix === 'GR') {
+            $prefix = 'EL';
+        }
+
+        // 1. If a default country is provided, we check if the VAT number matches its pattern.
+        if ($defaultCountry !== null) {
+            $defaultCountry = strtoupper($defaultCountry);
+            if ($defaultCountry === 'GR') {
+                $defaultCountry = 'EL';
+            }
+
+            // If the string starts EXPLICITEMENT by the default country's prefix or another supported country's prefix,
+            // AND the remaining length corresponds to a number without a prefix.
+            if ($prefix === $defaultCountry) {
+                return [
+                    $defaultCountry,
+                    substr($vatNumber, 2),
+                ];
+            }
+
+            // If the detected prefix is a supported country but different from the defaultCountry,
+            // we check if the complete string (without cutting anything) matches the pattern of the defaultCountry.
+            if (self::countryIsSupported($defaultCountry)) {
+                $pattern = '/^(?:' . self::$pattern_expression[$defaultCountry] . ')$/';
+                if (preg_match($pattern, $vatNumber) === 1) {
+                    // The complete number matches the local format of the defaultCountry !
+                    return [
+                        $defaultCountry,
+                        $vatNumber,
+                    ];
+                }
+            }
+        }
+
+        // 2. If the extracted prefix is a supported country (standard behavior without defaultCountry)
+        if (self::countryIsSupported($prefix)) {
+            return [
+                $prefix,
+                substr($vatNumber, 2),
+            ];
+        }
+
+        // 3. Fallback on defaultCountry if it was provided but didn't match the pattern above
+        if ($defaultCountry !== null) {
+            return [
+                $defaultCountry,
+                $vatNumber,
+            ];
+        }
+
         return [
-            substr($vatNumber, 0, 2),
+            $prefix,
             substr($vatNumber, 2),
         ];
     }

--- a/tests/VatValidatorTest.php
+++ b/tests/VatValidatorTest.php
@@ -5,19 +5,17 @@ namespace Danielebarbaro\LaravelVatEuValidator\Tests;
 use Danielebarbaro\LaravelVatEuValidator\VatValidator;
 use Danielebarbaro\LaravelVatEuValidator\VatValidatorServiceProvider;
 use Orchestra\Testbench\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class VatValidatorTest extends TestCase
 {
     protected VatValidator $validator;
-
-    protected string $fake_vat;
 
     protected function setUp(): void
     {
         parent::setUp();
 
         $this->validator = resolve(VatValidator::class);
-        $this->fake_vat = 'IT12345678901';
     }
 
     protected function getPackageProviders($app): array
@@ -27,53 +25,104 @@ class VatValidatorTest extends TestCase
         ];
     }
 
-    public function testVatValidFormatFail(): void
+    #[DataProvider('validVatFormatsProvider')]
+    /**
+     * @dataProvider validVatFormatsProvider
+     */
+    public function testValidateFormatSuccess(string $vatNumber, ?string $defaultCountry = null): void
     {
-        self::assertFalse($this->validator->validateFormat($this->fake_vat));
+        self::assertTrue(
+            $this->validator->validateFormat($vatNumber, $defaultCountry),
+            "Failed asserting that '{$vatNumber}' (default: {$defaultCountry}) is a valid format."
+        );
     }
 
-    public function testVatValidFormat(): void
+    #[DataProvider('invalidVatFormatsProvider')]
+    /**
+     * @dataProvider invalidVatFormatsProvider
+     */
+    public function testValidateFormatFailure(string $vatNumber, ?string $defaultCountry = null): void
     {
-        self::assertTrue($this->validator->validateFormat('IT10648200011'));
+        self::assertFalse(
+            $this->validator->validateFormat($vatNumber, $defaultCountry),
+            "Failed asserting that '{$vatNumber}' (default: {$defaultCountry}) is an invalid format."
+        );
     }
 
-    public function testVatWrongFormat(): void
+    public static function validVatFormatsProvider(): array
     {
-        $vat_numbers = [
-            '',
-            'IT1234567890',
-            'HU23395381',
-            'IT12345',
-            'foobar123',
+        return [
+            // Italy (Luhn + Office code)
+            'IT valid standard' => ['IT10648200011'],
+            'IT valid with spaces and dashes' => [' IT 106 482 000 11 '],
+            'IT valid with default country' => ['10648200011', 'IT'],
+
+            // France (Modulo 97 + Key alphabetic or numeric)
+            'FR valid numeric key' => ['FR40303265045'],
+            'FR valid alphabetic key (collision test HU)' => ['HU123456789', 'FR'],
+            'FR valid without prefix' => ['40303265045', 'FR'],
+            'FR valid alphabetic key colliding with HU prefix' => ['HU123456789', 'FR'],
+
+            // Hungary (Checksum pondered + 8 digits)
+            'HU valid standard' => ['HU28395515'],
+            'HU valid without prefix' => ['28395515', 'HU'],
+
+            // Greece (Conversion ISO GR -> VIES EL)
+            'EL valid standard' => ['EL094259216'],
+            'GR valid prefix alias' => ['GR094259216'],
+            'GR valid with default country' => ['094259216', 'GR'],
+
+            // Spain (Alternances formats)
+            'ES valid format 1 (A1234567B)' => ['ESA1234567B'],
+            'ES valid format 2 (12345678A)' => ['ES12345678A'],
+            'ES valid format 3 (A12345678)' => ['ESA12345678'],
+
+            // Ireland (Formats XI)
+            'XI valid standard 9 digits' => ['XI123456789'],
+            'XI valid special prefix GD' => ['XIGD123'],
+
+            // Other countries (Base formats)
+            'DE valid' => ['DE123456789'],
+            'AT valid' => ['ATU12345678'],
+            'BE valid' => ['BE0123456789'],
+            'DK valid' => ['DK12345678'],
+            'NL valid' => ['NL123456789B01'],
         ];
-        foreach ($vat_numbers as $vat) {
-            self::assertFalse($this->validator->validateFormat($vat));
-        }
     }
 
-    public function testVatExist(): void
+    public static function invalidVatFormatsProvider(): array
     {
-        self::assertFalse($this->validator->validateExistence($this->fake_vat));
+        return [
+            // Generic cases and character traps
+            'Empty string' => [''],
+            'Random string' => ['foobar123'],
+            'Unsupported country prefix' => ['US123456789'],
+            'Unknown default country fallback' => ['12345678', 'XX'],
+
+            // Non-isolated alternation trap (Regex bug that leaks)
+            'ES leakage test' => ['ESXX12345678AYY'], 
+            'XI leakage test' => ['XIFOO123456789012BAR'],
+
+            // Italy (Specific errors)
+            'IT invalid length' => ['IT1234567890'],
+            'IT invalid check digit (Luhn)' => ['IT10648200012'],
+            'IT all zeros' => ['IT00000000000'],
+            'IT invalid office code (000)' => ['IT12345670001'],
+
+            // France (Specific errors)
+            'FR invalid modulo 97 key' => ['FR41303265045'],
+            'FR invalid character in key (O or I forbidden)' => ['FRIO303265045'],
+
+            // Hungary (Specific errors)
+            'HU invalid checksum' => ['HU28395514'],
+            'HU wrong length' => ['HU2839551'],
+        ];
     }
 
-    public function testVatValid(): void
+    public function testCountryIsSupported(): void
     {
-        self::assertFalse($this->validator->validate($this->fake_vat));
-    }
-
-    public function testLuhnCheck(): void
-    {
-        self::assertIsInt($this->validator->luhnCheck($this->fake_vat));
-        self::assertNotEquals(0, $this->validator->luhnCheck($this->fake_vat));
-    }
-
-    public function testHuVatValidFormat(): void
-    {
-        self::assertTrue($this->validator->validateFormat('HU28395515'));
-    }
-
-    public function testHuVatInvalidFormat(): void
-    {
-        self::assertFalse($this->validator->validateFormat('HU28395514'));
+        self::assertTrue(VatValidator::countryIsSupported('FR'));
+        self::assertTrue(VatValidator::countryIsSupported('IT'));
+        self::assertFalse(VatValidator::countryIsSupported('US'));
     }
 }


### PR DESCRIPTION
- Group regex patterns with (?:...) to prevent unanchored pattern matching
- Refine splitVat priority when defaultCountry is provided
- Add algorithmic validation for FR (modulo 97)
- Correct algorithmic validations IT (Luhn + office code) and HU (checksum)
- Update test suite with PHPUnit DataProviders covering edge cases