### PR TITLE
Fix: wrap pattern expressions in non-capturing group to fix regex anc…

### DIFF
--- a/src/VatValidator.php
+++ b/src/VatValidator.php
@@ -77,7 +77,7 @@ class VatValidator
             return false;
         }
 
-        $validate_rule = preg_match('/^' . self::$pattern_expression[$country] . '$/', (string) $number) > 0;
+        $validate_rule = preg_match('/^(?:' . self::$pattern_expression[$country] . ')$/', (string) $number) > 0;
 
         if ($validate_rule && $country === 'IT') {
             $result = self::luhnCheck($number);

--- a/tests/VatValidatorTest.php
+++ b/tests/VatValidatorTest.php
@@ -32,6 +32,16 @@ class VatValidatorTest extends TestCase
         self::assertFalse($this->validator->validateFormat($this->fake_vat));
     }
 
+    public static function invalidVatFormatsProvider(): array
+    {
+        return [
+        // Non-isolated alternation trap (Regex bug that leaks)
+        'ES leakage test' => ['ESXX12345678AYY'],
+        'IE leakage test' => ['IEXX1234567WAYY'],
+        'GB leakage test' => ['GBXX123456789YY'],
+        ];
+    }
+
     public function testVatValidFormat(): void
     {
         self::assertTrue($this->validator->validateFormat('IT10648200011'));

--- a/tests/VatValidatorTest.php
+++ b/tests/VatValidatorTest.php
@@ -5,6 +5,7 @@ namespace Danielebarbaro\LaravelVatEuValidator\Tests;
 use Danielebarbaro\LaravelVatEuValidator\VatValidator;
 use Danielebarbaro\LaravelVatEuValidator\VatValidatorServiceProvider;
 use Orchestra\Testbench\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class VatValidatorTest extends TestCase
 {
@@ -32,13 +33,23 @@ class VatValidatorTest extends TestCase
         self::assertFalse($this->validator->validateFormat($this->fake_vat));
     }
 
+    #[DataProvider('invalidVatFormatsProvider')]
+    public function testVatFormatAlternationLeakage(string $vat_number): void
+    {
+        self::assertFalse($this->validator->validateFormat($vat_number));
+    }
+
+    /**
+     * Numbers whose alternation branches used to match unanchored.
+     *
+     * @return array<string, array<string>>
+     */
     public static function invalidVatFormatsProvider(): array
     {
         return [
-        // Non-isolated alternation trap (Regex bug that leaks)
-        'ES leakage test' => ['ESXX12345678AYY'],
-        'IE leakage test' => ['IEXX1234567WAYY'],
-        'GB leakage test' => ['GBXX123456789YY'],
+            'ES leakage test' => ['ESXX12345678AYY'],
+            'IE leakage test' => ['IEXX1234567WAYY'],
+            'GB leakage test' => ['GBXX123456789012YY'],
         ];
     }
 


### PR DESCRIPTION
Enclose country expressions inside a non-capturing group `^(?: ... )$` within `validateFormat()` to prevent unanchored alternation branches from matching partial strings (e.g. ESXX12345678AYY).

Adding tests.