### PR TITLE
Add Modulo 97 and character set validation for French (FR) VAT

### DIFF
--- a/src/VatValidator.php
+++ b/src/VatValidator.php
@@ -25,7 +25,7 @@ class VatValidator
         'EL' => '\d{9}',
         'ES' => '[A-Z]\d{7}[A-Z]|\d{8}[A-Z]|[A-Z]\d{8}',
         'FI' => '\d{8}',
-        'FR' => '([A-Z]{2}|\d{2})\d{9}',
+        'FR' => '([0-9A-HJ-NP-Z]{2})\d{9}',
         'GB' => '\d{9}|\d{12}|(GD|HA)\d{3}',
         'HR' => '\d{11}',
         'HU' => '\d{8}',
@@ -79,6 +79,10 @@ class VatValidator
         }
 
         $validate_rule = preg_match('/^(?:' . self::$pattern_expression[$country] . ')$/', (string) $number) > 0;
+
+        if ($validate_rule && $country === 'FR') {
+            return $this->validateFrVat($number);
+        }
 
         if ($validate_rule && $country === 'IT') {
             $result = self::luhnCheck($number);
@@ -158,6 +162,32 @@ class VatValidator
         $calculatedChecksum = (10 - ($sum % 10)) % 10;
 
         return $calculatedChecksum === $checksum;
+    }
+
+    /**
+     * Validates a French VAT number (Modulo 97 for numeric keys, strict character set for alpha keys).
+     *
+     * @param string $vatNumber 11-character FR VAT body (2-char key + 9-digit SIREN)
+     * @return bool
+     */
+    private function validateFrVat(string $vatNumber): bool
+    {
+        if (strlen($vatNumber) !== 11) {
+            return false;
+        }
+
+        $key = strtoupper(substr($vatNumber, 0, 2));
+        $siren = substr($vatNumber, 2, 9);
+
+        // Validation with Modulo 97
+        if (ctype_digit($key)) {
+            $expectedKey = (12 + 3 * ((int) $siren % 97)) % 97;
+
+            return (int) $key === $expectedKey;
+        }
+
+        // Validation with strict character set for alpha keys
+        return preg_match('/^[0-9A-HJ-NP-Z]{2}$/', $key) === 1;
     }
 
     /**

--- a/src/VatValidator.php
+++ b/src/VatValidator.php
@@ -80,10 +80,6 @@ class VatValidator
 
         $validate_rule = preg_match('/^(?:' . self::$pattern_expression[$country] . ')$/', (string) $number) > 0;
 
-        if ($validate_rule && $country === 'FR') {
-            return $this->validateFrVat($number);
-        }
-
         if ($validate_rule && $country === 'IT') {
             $result = self::luhnCheck($number);
 
@@ -92,6 +88,10 @@ class VatValidator
 
         if ($validate_rule && $country === 'HU') {
             return $this->validateHuVat($number);
+        }
+
+        if ($validate_rule && $country === 'FR') {
+            return $this->validateFrVat($number);
         }
 
         return $validate_rule;
@@ -165,29 +165,25 @@ class VatValidator
     }
 
     /**
-     * Validates a French VAT number (Modulo 97 for numeric keys, strict character set for alpha keys).
+     * Validates a French VAT number.
      *
-     * @param string $vatNumber 11-character FR VAT body (2-char key + 9-digit SIREN)
+     * Only numeric keys carry a checksum; alphanumeric ones are already
+     * constrained by the format pattern.
+     *
+     * @param string $vatNumber
      * @return bool
      */
     private function validateFrVat(string $vatNumber): bool
     {
-        if (strlen($vatNumber) !== 11) {
-            return false;
+        $key = substr($vatNumber, 0, 2);
+
+        if (! ctype_digit($key)) {
+            return true;
         }
 
-        $key = strtoupper(substr($vatNumber, 0, 2));
-        $siren = substr($vatNumber, 2, 9);
+        $siren = (int) substr($vatNumber, 2, 9);
 
-        // Validation with Modulo 97
-        if (ctype_digit($key)) {
-            $expectedKey = (12 + 3 * ((int) $siren % 97)) % 97;
-
-            return (int) $key === $expectedKey;
-        }
-
-        // Validation with strict character set for alpha keys
-        return preg_match('/^[0-9A-HJ-NP-Z]{2}$/', $key) === 1;
+        return (int) $key === (12 + 3 * ($siren % 97)) % 97;
     }
 
     /**

--- a/tests/Functional/VatValidatorRestFunctionalTest.php
+++ b/tests/Functional/VatValidatorRestFunctionalTest.php
@@ -291,7 +291,7 @@ class VatValidatorRestFunctionalTest extends TestCase
     {
         return [
             'Germany' => ['DE123456789'],
-            'France' => ['FR12345678901'],
+            'France' => ['FR83404833048'],
             'Spain' => ['ESA12345674'],
             'Netherlands' => ['NL123456789B01'],
             'Belgium' => ['BE0123456789'],

--- a/tests/Functional/VatValidatorSoapFunctionalTest.php
+++ b/tests/Functional/VatValidatorSoapFunctionalTest.php
@@ -170,7 +170,7 @@ class VatValidatorSoapFunctionalTest extends TestCase
     {
         return [
             'Germany' => ['DE123456789'],
-            'France' => ['FR12345678901'],
+            'France' => ['FR83404833048'],
             'Spain' => ['ESA12345674'],
             'Netherlands' => ['NL123456789B01'],
             'Belgium' => ['BE0123456789'],

--- a/tests/VatValidatorTest.php
+++ b/tests/VatValidatorTest.php
@@ -51,6 +51,18 @@ class VatValidatorTest extends TestCase
         self::assertFalse($this->validator->validateFormat($vat_number));
     }
 
+    #[DataProvider('validFrVatFormatsProvider')]
+    public function testFrVatValidFormat(string $vat_number): void
+    {
+        self::assertTrue($this->validator->validateFormat($vat_number));
+    }
+
+    #[DataProvider('invalidFrVatFormatsProvider')]
+    public function testFrVatInvalidFormat(string $vat_number): void
+    {
+        self::assertFalse($this->validator->validateFormat($vat_number));
+    }
+
     /**
      * Numbers whose alternation branches used to match unanchored.
      *
@@ -94,6 +106,32 @@ class VatValidatorTest extends TestCase
             'XI invalid HA too long' => ['XIHA1234'],
             'XI invalid unknown prefix' => ['XIZZ123'],
             'XI leakage test' => ['XIXX123456789012YY'],
+        ];
+    }
+
+    /**
+     * @return array<string, array<string>>
+     */
+    public static function validFrVatFormatsProvider(): array
+    {
+        return [
+            'FR valid numeric key (Modulo 97)' => ['FR40303265045'], 
+            'FR valid SIREN with leading zeros' => ['FR34000123456'],
+            'FR valid alphabetic key without forbidden chars' => ['FRHU356000000'],
+            'FR valid alphanumeric key' => ['FR2A356000000'],
+        ];
+    }
+
+    /**
+     * @return array<string, array<string>>
+     */
+    public static function invalidFrVatFormatsProvider(): array
+    {
+        return [
+            'FR invalid modulo 97 key' => ['FR41303265045'],
+            'FR forbidden letter O in key' => ['FRO0303265045'],
+            'FR forbidden letter I in key' => ['FRI0303265045'],
+            'FR invalid SIREN length' => ['FR4030326504'],
         ];
     }
 

--- a/tests/VatValidatorTest.php
+++ b/tests/VatValidatorTest.php
@@ -115,7 +115,9 @@ class VatValidatorTest extends TestCase
     public static function validFrVatFormatsProvider(): array
     {
         return [
-            'FR valid numeric key (Modulo 97)' => ['FR40303265045'], 
+            'FR valid numeric key (Modulo 97)' => ['FR40303265045'],
+            'FR valid numeric key from the official example' => ['FR83404833048'],
+            'FR valid numeric key with a leading zero' => ['FR00100000012'],
             'FR valid SIREN with leading zeros' => ['FR34000123456'],
             'FR valid alphabetic key without forbidden chars' => ['FRHU356000000'],
             'FR valid alphanumeric key' => ['FR2A356000000'],
@@ -129,9 +131,12 @@ class VatValidatorTest extends TestCase
     {
         return [
             'FR invalid modulo 97 key' => ['FR41303265045'],
-            'FR forbidden letter O in key' => ['FRO0303265045'],
-            'FR forbidden letter I in key' => ['FRI0303265045'],
-            'FR invalid SIREN length' => ['FR4030326504'],
+            'FR forbidden letter O in first key char' => ['FRO0303265045'],
+            'FR forbidden letter I in first key char' => ['FRI0303265045'],
+            'FR forbidden letter O in second key char' => ['FR1O303265045'],
+            'FR forbidden letter I in second key char' => ['FR1I303265045'],
+            'FR SIREN too short' => ['FR4030326504'],
+            'FR SIREN too long' => ['FR403032650456'],
         ];
     }
 


### PR DESCRIPTION
### Summary
Implements validation logic for French (`FR`) VAT numbers:
1. **Numeric Keys:** Validates the two-digit key against the official Modulo 97 algorithm `(12 + 3 * (SIREN % 97)) % 97`.
2. **Alpha/Alphanumeric Keys:** Restricts the 2-character key to allowed characters `[0-9A-HJ-NP-Z]`, excluding forbidden ambiguous letters `I` and `O`.

### Changes
- Updated `$pattern_expression['FR']` regex to exclude `I` and `O` from alphabetic key positions.
- Added `validateFrVat()` method in `VatValidator`.
- Added comprehensive unit tests covering numeric keys (with and without leading zeros), valid/invalid alpha keys, and forbidden characters.

### Test Plan
- [x] Ran `composer test` — all tests pass.
- [x] Ran `composer lint` — clean code style.