### PR TITLE
Fixes Swiss VAT validation, improves whitespace handling for all countries

### DIFF
--- a/src/VatValidator.php
+++ b/src/VatValidator.php
@@ -16,7 +16,7 @@ class VatValidator
         'AT' => 'U[A-Z\d]{8}',
         'BE' => '(0\d{9}|\d{10})',
         'BG' => '\d{9,10}',
-        'CH' => '\d{6}|E\d{9}(\s?(TVA|MWST|IVA))?',
+        'CH' => '\d{6}|E\d{9}(TVA|MWST|IVA)?',
         'CY' => '\d{8}[A-Z]',
         'CZ' => '\d{8,10}',
         'DE' => '\d{9}',
@@ -204,9 +204,7 @@ class VatValidator
      */
     private function vatCleaner(string $vatNumber): string
     {
-        $vatNumber_no_spaces = trim($vatNumber);
-
-        return strtoupper($vatNumber_no_spaces);
+        return strtoupper(preg_replace('/\s+/', '', $vatNumber));
     }
 
     /**

--- a/tests/VatValidatorTest.php
+++ b/tests/VatValidatorTest.php
@@ -166,6 +166,12 @@ class VatValidatorTest extends TestCase
             'CH valid lowercase 6 digits' => ['ch123456'],
             'CH valid lowercase E + 9 digits' => ['che123456789'],
             'CH valid E + 9 digits + lowercase suffix' => ['CHE123456789tva'],
+            'CH valid with internal space (1)' => ['CH E123456789'],
+            'CH valid with internal space (2)' => ['CH E123456789 TVA'],
+            'CH valid with multiple internal spaces' => ['CH   E123456789   TVA'],
+            'CH valid lowercase E + 9 digits + suffix' => ['che123456789tva'],
+            'CH valid with surrounding spaces' => [' CH 123456 '],
+            'CH valid with surrounding spaces + suffix' => [' CH E123456789 IVA '],
         ];
     }
 
@@ -184,6 +190,11 @@ class VatValidatorTest extends TestCase
             'CH invalid double suffix' => ['CHE123456789TVAMWST'],
             'CH invalid special chars' => ['CH12-34-56'],
             'CH invalid missing E' => ['CH123456789TVA'],
+            'CH invalid E + 9 digits + too long suffix' => ['CHE123456789TVA123'],
+            'CH invalid E + 9 digits + incomplete suffix' => ['CHE123456789T'],
+            'CH invalid country code' => ['XX123456'],
+            'CH invalid too short' => ['CH'],
+            'CH invalid E only' => ['CHE'],
         ];
     }
 


### PR DESCRIPTION
### Changes:
- **CH regex**: updated to `\d{6} E\d{9}(TVA|MWST|IVA)?` to correctly validate all Swiss VAT formats.
- **`vatCleaner()`**: now removes **all whitespace** (not just trimming) to ensure consistent validation.
- **Tests**: added comprehensive test coverage for Switzerland, including edge cases (spaces, suffixes, case sensitivity).

### Why:
Ensures compliance with official Swiss VAT rules and handles user input variations (spaces, lowercase letters) robustly.