### PR TITLE
Reject BE, AT and SI numbers that cannot be issued

### DIFF
--- a/src/VatValidator.php
+++ b/src/VatValidator.php
@@ -13,8 +13,8 @@ class VatValidator
      * @link http://ec.europa.eu/taxation_customs/vies/faq.html?locale=en#item_11
      */
     protected static array $pattern_expression = [
-        'AT' => 'U[A-Z\d]{8}',
-        'BE' => '(0\d{9}|\d{10})',
+        'AT' => 'U\d{8}',
+        'BE' => '[01]\d{9}',
         'BG' => '\d{9,10}',
         'CH' => '\d{6}|E\d{9}(\s?(TVA|MWST|IVA))?',
         'CY' => '\d{8}[A-Z]',
@@ -40,7 +40,7 @@ class VatValidator
         'PT' => '\d{9}',
         'RO' => '\d{2,10}',
         'SE' => '\d{12}',
-        'SI' => '\d{8}',
+        'SI' => '[1-9]\d{7}',
         'SK' => '\d{10}',
         'XI' => '\d{9}|\d{12}|(GD|HA)\d{3}',
     ];

--- a/tests/VatValidatorTest.php
+++ b/tests/VatValidatorTest.php
@@ -75,6 +75,42 @@ class VatValidatorTest extends TestCase
         self::assertFalse($this->validator->validateFormat($vat_number));
     }
 
+    #[DataProvider('validBeVatFormatsProvider')]
+    public function testBeVatValidFormat(string $vat_number): void
+    {
+        self::assertTrue($this->validator->validateFormat($vat_number));
+    }
+
+    #[DataProvider('invalidBeVatFormatsProvider')]
+    public function testBeVatInvalidFormat(string $vat_number): void
+    {
+        self::assertFalse($this->validator->validateFormat($vat_number));
+    }
+
+    #[DataProvider('validAtVatFormatsProvider')]
+    public function testAtVatValidFormat(string $vat_number): void
+    {
+        self::assertTrue($this->validator->validateFormat($vat_number));
+    }
+
+    #[DataProvider('invalidAtVatFormatsProvider')]
+    public function testAtVatInvalidFormat(string $vat_number): void
+    {
+        self::assertFalse($this->validator->validateFormat($vat_number));
+    }
+
+    #[DataProvider('validSiVatFormatsProvider')]
+    public function testSiVatValidFormat(string $vat_number): void
+    {
+        self::assertTrue($this->validator->validateFormat($vat_number));
+    }
+
+    #[DataProvider('invalidSiVatFormatsProvider')]
+    public function testSiVatInvalidFormat(string $vat_number): void
+    {
+        self::assertFalse($this->validator->validateFormat($vat_number));
+    }
+
     /**
      * Numbers whose alternation branches used to match unanchored.
      *
@@ -149,6 +185,84 @@ class VatValidatorTest extends TestCase
             'FR forbidden letter I in second key char' => ['FR1I303265045'],
             'FR SIREN too short' => ['FR4030326504'],
             'FR SIREN too long' => ['FR403032650456'],
+        ];
+    }
+
+    /**
+     * @return array<string, array<string>>
+     */
+    public static function validBeVatFormatsProvider(): array
+    {
+        return [
+            'BE valid starting with 0' => ['BE0123456789'],
+            'BE valid starting with 1' => ['BE1123456789'],
+            'BE valid lowercase' => ['be0123456789'],
+            'BE valid with surrounding spaces' => [' BE0123456789 '],
+        ];
+    }
+
+    /**
+     * @return array<string, array<string>>
+     */
+    public static function invalidBeVatFormatsProvider(): array
+    {
+        return [
+            'BE invalid starting with 2' => ['BE2123456789'],
+            'BE invalid starting with 9' => ['BE9123456789'],
+            'BE invalid 9 digits' => ['BE012345678'],
+            'BE invalid 11 digits' => ['BE01234567890'],
+            'BE invalid letters' => ['BE012345678A'],
+        ];
+    }
+
+    /**
+     * @return array<string, array<string>>
+     */
+    public static function validAtVatFormatsProvider(): array
+    {
+        return [
+            'AT valid U + 8 digits' => ['ATU12345678'],
+            'AT valid lowercase' => ['atu12345678'],
+            'AT valid with surrounding spaces' => [' ATU12345678 '],
+        ];
+    }
+
+    /**
+     * @return array<string, array<string>>
+     */
+    public static function invalidAtVatFormatsProvider(): array
+    {
+        return [
+            'AT invalid letters after U' => ['ATU1234567A'],
+            'AT invalid missing U' => ['AT123456789'],
+            'AT invalid 7 digits' => ['ATU1234567'],
+            'AT invalid 9 digits' => ['ATU123456789'],
+        ];
+    }
+
+    /**
+     * @return array<string, array<string>>
+     */
+    public static function validSiVatFormatsProvider(): array
+    {
+        return [
+            'SI valid 8 digits' => ['SI12345678'],
+            'SI valid starting with 9' => ['SI98765432'],
+            'SI valid lowercase' => ['si12345678'],
+            'SI valid with surrounding spaces' => [' SI12345678 '],
+        ];
+    }
+
+    /**
+     * @return array<string, array<string>>
+     */
+    public static function invalidSiVatFormatsProvider(): array
+    {
+        return [
+            'SI invalid leading zero' => ['SI01234567'],
+            'SI invalid 7 digits' => ['SI1234567'],
+            'SI invalid 9 digits' => ['SI123456789'],
+            'SI invalid letters' => ['SI1234567A'],
         ];
     }
 


### PR DESCRIPTION
## Problem

Three patterns accept numbers that no national register issues.

**BE** `(0\d{9}|\d{10})`. The first branch is a subset of the second, so the pattern is equivalent to `\d{10}` and accepts any ten digits. Belgian enterprise numbers always start with `0` or `1`. Reported by @bestmomo in #74.

**AT** `U[A-Z\d]{8}`. The eight characters after the `U` are digits, not alphanumerics, so `ATU1234567A` is accepted today.

**SI** `\d{8}`. The first digit of a Slovenian tax number is never `0`, so `SI01234567` is accepted today.

## Change

```diff
-'AT' => 'U[A-Z\d]{8}',
-'BE' => '(0\d{9}|\d{10})',
+'AT' => 'U\d{8}',
+'BE' => '[01]\d{9}',

-'SI' => '\d{8}',
+'SI' => '[1-9]\d{7}',
```

## Tests

24 cases added to `VatValidatorTest`, one provider pair per country, covering the accepted leading digits, lowercase input, surrounding spaces, wrong lengths and stray letters.

## Notes

All three changes are restrictive. Numbers accepted before and rejected now could never exist, and the VIES existence check already discarded them in `validate()`. Only `validateFormat()` changes behaviour. If you cache format results, consider invalidating the `BE`, `AT` and `SI` ones.

Checksums are still not verified for these countries (BE modulo 97, SI modulo 11). That is out of scope here.

The CHANGELOG entry is left to the release commit, as in previous releases.

References:

* https://ec.europa.eu/taxation_customs/vies/
* https://en.wikipedia.org/wiki/VAT_identification_number